### PR TITLE
Update to current Atom API

### DIFF
--- a/keymaps/ide-flow.cson
+++ b/keymaps/ide-flow.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'atom-text-editor':
   'cmd-f12': 'ide-flow:goto-def'

--- a/lib/flow-autocomplete-provider.coffee
+++ b/lib/flow-autocomplete-provider.coffee
@@ -6,10 +6,10 @@ module.exports =
   selector: '.source.js, .source.jsx'
   blacklist: '.source.js .comment'
   requestHandler: (options) ->
-    editor = atom.workspace.getActiveEditor()
+    editor = atom.workspace.getActiveTextEditor()
     return unless isFlowSource editor
     bufferPt = editor.getCursorBufferPosition()
-    selection = editor.getSelection()
+    selection = editor.getLastSelection()
     prefix = options.prefix
     results = utilFlowCommand.autocompleteSync
       bufferPt: bufferPt

--- a/lib/ide-flow.coffee
+++ b/lib/ide-flow.coffee
@@ -7,10 +7,12 @@ module.exports =
     {BufferedProcess} = require 'atom'
     {PluginManager} = require './plugin-manager'
     _pluginManager = new PluginManager()
-    atom.workspaceView.command "ide-flow:check", ->
-      _pluginManager.check()
-    atom.workspaceView.command "ide-flow:goto-def", ->
-      _pluginManager.gotoDefinition()
+    atom.commands.add 'atom-workspace',
+      "ide-flow:check", ->
+        _pluginManager.check()
+    atom.commands.add 'atom-workspace',
+      "ide-flow:goto-def", ->
+        _pluginManager.gotoDefinition()
 
   deactivate: ->
     _pluginManager.deactivate()

--- a/lib/plugin-manager.coffee
+++ b/lib/plugin-manager.coffee
@@ -7,11 +7,13 @@ class PluginManager
     @checkResults = []
 
     # Register an EditorControl for each editor view
-    @controlSubscription = atom.workspaceView.eachEditorView (editorView) =>
-      editorView.flowController = new EditorControl(editorView, this)
+    @controlSubscription = atom.workspace.observeTextEditors (editor) =>
+      editorView = atom.views.getView(editor)
+      editorView.flowController = new EditorControl(editor, this)
 
   deactivate: () ->
-    for editorView in atom.workspaceView.getEditorViews()
+    for editor in atom.workspace.getTextEditors()
+      editorView = atom.views.getView(editor)
       editorView.flowController?.deactivate()
       editorView.flowController = null
     @controlSubscription?.off()
@@ -34,7 +36,7 @@ class PluginManager
 
   check: ->
     return if @checkTurnedOff? and @checkTurnedOff
-    fileName = atom.workspaceView.getActiveView()?.getEditor().getPath()
+    fileName = atom.workspace.getActiveTextEditor()?.getPath()
     return unless fileName?
 
     utilFlowCommand.check
@@ -53,7 +55,8 @@ class PluginManager
 
   # Update every editor view with results
   updateAllEditorViewsWithResults: ->
-    for editorView in atom.workspaceView.getEditorViews()
+    for editor in atom.workspace.getTextEditors()
+      editorView = atom.views.getView(editor)
       editorView.flowController?.resultsUpdated()
 
   typeAtPos: ({bufferPt, fileName, text, onResult}) ->

--- a/lib/tooltip-view.coffee
+++ b/lib/tooltip-view.coffee
@@ -1,4 +1,5 @@
-{$, View} = require 'atom'
+{View} = require 'atom-space-pen-views'
+$ = require 'jquery'
 
 class TooltipView extends View
   @content: ->

--- a/lib/util-flow-command.coffee
+++ b/lib/util-flow-command.coffee
@@ -49,7 +49,7 @@ runSync = ({args, cwd, input}) ->
 module.exports =
 
   startServer: ->
-    editor = atom.workspace.activePaneItem
+    editor = atom.workspace.getActivePaneItem()
     filename = editor.getPath()
     dir = path.dirname filename
     process = run

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -3,11 +3,12 @@ path = require 'path'
 isFlowSource = (editor) ->
   buffer = editor.getBuffer()
   fname = buffer.getUri()
+  isFlow = false
   if path.extname(fname) in ['.js', '.jsx']
-    if buffer.lineForRow(0).match(/@flow/)
-      return true
-    return false
-  return false
+    if buffer.lineForRow(buffer.nextNonBlankRow -1).match(/\/\*/)
+      buffer.scan /\/\*(.|\n)*?\*\//, (scan) =>
+        isFlow = true if scan.matchText.match(/@flow/)
+  return isFlow
 
 # pixel position from mouse event
 pixelPositionFromMouseEvent = (editor, event) ->

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,26 +1,33 @@
 path = require 'path'
 
 isFlowSource = (editor) ->
-  if path.extname(editor.getPath()) in ['.js', '.jsx']
-    if editor.getTextInBufferRange([[0,0], [100,0]]).match(/@flow/)
+  buffer = editor.getBuffer()
+  fname = buffer.getUri()
+  if path.extname(fname) in ['.js', '.jsx']
+    if buffer.lineForRow(0).match(/@flow/)
       return true
     return false
   return false
 
 # pixel position from mouse event
-pixelPositionFromMouseEvent = (editorView, event) ->
+pixelPositionFromMouseEvent = (editor, event) ->
   {clientX, clientY} = event
-  linesClientRect = editorView.find('.lines')[0].getBoundingClientRect()
+  elem = atom.views.getView(editor)
+  linesClientRect = getElementsByClass(elem, ".lines")[0].getBoundingClientRect()
   top = clientY - linesClientRect.top
   left = clientX - linesClientRect.left
   {top, left}
 
 # screen position from mouse event
-screenPositionFromMouseEvent = (editorView, event) ->
-  editorView.getModel().screenPositionForPixelPosition(pixelPositionFromMouseEvent(editorView, event))
+screenPositionFromMouseEvent = (editor, event) ->
+  editor.screenPositionForPixelPosition(pixelPositionFromMouseEvent(editor, event))
+
+getElementsByClass = (elem,klass) ->
+  elem.rootElement.querySelectorAll(klass)
 
 module.exports = {
   isFlowSource,
   pixelPositionFromMouseEvent,
-  screenPositionFromMouseEvent
+  screenPositionFromMouseEvent,
+  getElementsByClass
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -5,7 +5,7 @@ isFlowSource = (editor) ->
   fname = buffer.getUri()
   isFlow = false
   if path.extname(fname) in ['.js', '.jsx']
-    if buffer.lineForRow(buffer.nextNonBlankRow -1).match(/\/\*/)
+    if buffer.lineForRow(buffer.nextNonBlankRow -1)?.match(/\/\*/)
       buffer.scan /\/\*(.|\n)*?\*\//, (scan) =>
         isFlow = true if scan.matchText.match(/@flow/)
   return isFlow

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "figlet": "1.0.8",
     "emissary": "~1.2.1",
-    "fuzzaldrin": "~2.1.0"
+    "fuzzaldrin": "~2.1.0",
+    "jquery": "^2",
+    "atom-space-pen-views": "^2.0.3"
   },
   "providedServices": {
     "autocomplete.provider": {

--- a/spec/fixtures/is-flow-source.coffee
+++ b/spec/fixtures/is-flow-source.coffee
@@ -1,0 +1,66 @@
+module.exports = [
+  {
+    text: """
+          /* @flow */
+
+          var n = 0;
+          """
+    desc: "simple top comment"
+    match: true
+  }
+  {
+    text: """
+          var n = 0;
+
+          /* @flow */
+          """
+    desc: "not top comment"
+    match: false
+  }
+  {
+    text: """
+
+
+          /**
+           * Bla bla bla
+           *
+           * LICENSE LICENSE LICENSE
+           *
+           * @flow
+           */
+
+          var n = 0;
+          """
+    desc: "Long comment and blank lines"
+    match: true
+  }
+  {
+    text: """
+
+
+          /**
+           * Bla bla bla
+           *
+           * LICENSE LICENSE LICENSE
+           *
+           */
+
+          var n = 0;
+          """
+    desc: "Long comment and blank lines no @flow"
+    match: false
+  }
+  {
+    text: """
+          /**
+           * Bla bla bla
+           */
+
+          /* @flow */
+
+          var n = 0;
+          """
+    desc: "@flow not in first comment"
+    match: false
+  }
+]

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -5,9 +5,11 @@ utils = require '../lib/utils'
 describe 'is Flow source check', ->
   beforeEach ->
     waitsForPromise ->
-      atom.workspace.open('test.js').then (editor) ->
+      atom.workspace.open 'test.js'
   isFlowTests.forEach (test) ->
     it 'should handle: ' + test.desc, ->
       editor = atom.workspace.getActiveTextEditor()
       editor.setText test.text
       expect(utils.isFlowSource editor).toEqual test.match
+  it 'should handle an empty buffer', ->
+    expect(utils.isFlowSource atom.workspace.getActiveTextEditor()).toEqual false

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -1,0 +1,13 @@
+isFlowTests = require './fixtures/is-flow-source'
+{TextEditor} = require 'atom'
+utils = require '../lib/utils'
+
+describe 'is Flow source check', ->
+  beforeEach ->
+    waitsForPromise ->
+      atom.workspace.open('test.js').then (editor) ->
+  isFlowTests.forEach (test) ->
+    it 'should handle: ' + test.desc, ->
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setText test.text
+      expect(utils.isFlowSource editor).toEqual test.match

--- a/styles/ide-flow.less
+++ b/styles/ide-flow.less
@@ -7,7 +7,7 @@
 @import "tooltips";
 
 @error-color: #b22222;
-.editor {
+atom-text-editor::shadow {
   .ide-flow-error {
     background-color: @background-color-highlight;
     z-index: 3;


### PR DESCRIPTION
Mostly taken from ide-haskell. I think this fixes everything for the current version of Atom. There are no deprecation warnings now and error checking, hovering for types and autocomplete seems to work.