### PR TITLE
Support "// @flow" syntax

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -8,6 +8,9 @@ isFlowSource = (editor) ->
     if buffer.lineForRow(buffer.nextNonBlankRow -1)?.match(/\/\*/)
       buffer.scan /\/\*(.|\n)*?\*\//, (scan) =>
         isFlow = true if scan.matchText.match(/@flow/)
+    if buffer.lineForRow(buffer.nextNonBlankRow -1)?.match(/\/\//)
+      buffer.scan /\/\/(.|\n)*?/, (scan) =>
+        isFlow = true if scan.lineText.match(/@flow/)
   return isFlow
 
 # pixel position from mouse event


### PR DESCRIPTION
We've got colleagues who don't use Atom, and they keep using the `// @flow` syntax to mark files as flow-checked. This pull request adds support for that syntax.