### PR TITLE
fix autocomplete

### DIFF
--- a/lib/flow-autocomplete-provider.coffee
+++ b/lib/flow-autocomplete-provider.coffee
@@ -21,7 +21,7 @@ module.exports =
         text: editor.getText()
         onResult: (results) =>
           console.log results
-          filteredResults = fuzzaldrin.filter results, prefix, key: "name"
+          filteredResults = fuzzaldrin.filter results.result, prefix, key: "name"
           suggestions = []
           for result in filteredResults
             suggestions.push


### PR DESCRIPTION
As of Flow v0.21, autocomplete returns not an array, but an object with the result key.

```
{"result":[{"name":"webpack","type":"","func_details":null,"path":"/Users/howard/p/quickpack/src/try-flow.js","line":2,"endline":2,"star
```
